### PR TITLE
Add device calendar open preference

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,6 +87,7 @@ export default function App() {
         show_device_calendar_busy: (fallback.show_device_calendar_busy ?? pref.show_device_calendar_busy ?? false),
         show_device_calendar_titles: (fallback.show_device_calendar_titles ?? pref.show_device_calendar_titles ?? false),
         device_calendar_included_ids: includedIds,
+        device_calendar_open_in: (fallback.device_calendar_open_in ?? pref.device_calendar_open_in ?? 'gaply') as any,
       } as UserPreferences;
     } catch {
       return pref;

--- a/components/SettingsContent.tsx
+++ b/components/SettingsContent.tsx
@@ -91,16 +91,19 @@ export function SettingsContent({ session, preferences, onSignOut, onPreferences
       const nextBusy = !!fallback.show_device_calendar_busy;
       const nextTitles = !!fallback.show_device_calendar_titles;
       const nextIds = Array.isArray(fallback.device_calendar_included_ids) ? fallback.device_calendar_included_ids : [];
+      const nextOpenIn = (fallback.device_calendar_open_in === 'calendar_app') ? 'calendar_app' : 'gaply';
       const hasDiff = (
         (localPreferences.show_device_calendar_busy ?? false) !== nextBusy ||
         (localPreferences.show_device_calendar_titles ?? false) !== nextTitles ||
-        JSON.stringify(localPreferences.device_calendar_included_ids || []) !== JSON.stringify(nextIds)
+        JSON.stringify(localPreferences.device_calendar_included_ids || []) !== JSON.stringify(nextIds) ||
+        (localPreferences.device_calendar_open_in ?? 'gaply') !== nextOpenIn
       );
       if (hasDiff) {
         // Apply without triggering server autosave; local-only path handles persistence
         updatePreference('show_device_calendar_busy', nextBusy);
         updatePreference('show_device_calendar_titles', nextTitles);
         updatePreference('device_calendar_included_ids', nextIds);
+        updatePreference('device_calendar_open_in', nextOpenIn);
       }
     } catch {}
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -330,7 +333,8 @@ export function SettingsContent({ session, preferences, onSignOut, onPreferences
   const LOCAL_ONLY_KEYS = new Set([
     'show_device_calendar_busy',
     'show_device_calendar_titles',
-    'device_calendar_included_ids'
+    'device_calendar_included_ids',
+    'device_calendar_open_in'
   ]);
 
   const updatePreferences = (patch: Partial<UserPreferences>) => {
@@ -358,7 +362,8 @@ export function SettingsContent({ session, preferences, onSignOut, onPreferences
         const devicePrefs = {
           show_device_calendar_busy: next.show_device_calendar_busy ?? false,
           show_device_calendar_titles: next.show_device_calendar_titles ?? false,
-          device_calendar_included_ids: next.device_calendar_included_ids ?? []
+          device_calendar_included_ids: next.device_calendar_included_ids ?? [],
+          device_calendar_open_in: next.device_calendar_open_in ?? 'gaply'
         };
         localStorage.setItem(`gaply_device_calendar_${userId}`, JSON.stringify(devicePrefs));
       } catch {}
@@ -396,7 +401,8 @@ export function SettingsContent({ session, preferences, onSignOut, onPreferences
       calendar_working_days: normalizedWorkingDays,
       show_device_calendar_busy: (localPreferences?.show_device_calendar_busy ?? false),
       show_device_calendar_titles: (localPreferences?.show_device_calendar_titles ?? false),
-      device_calendar_included_ids: (localPreferences?.device_calendar_included_ids ?? [])
+      device_calendar_included_ids: (localPreferences?.device_calendar_included_ids ?? []),
+      device_calendar_open_in: (localPreferences?.device_calendar_open_in ?? 'gaply')
     } as UserPreferences;
   };
 
@@ -482,7 +488,8 @@ export function SettingsContent({ session, preferences, onSignOut, onPreferences
           const devicePrefs = {
             show_device_calendar_busy: next.show_device_calendar_busy ?? false,
             show_device_calendar_titles: next.show_device_calendar_titles ?? false,
-            device_calendar_included_ids: next.device_calendar_included_ids ?? []
+            device_calendar_included_ids: next.device_calendar_included_ids ?? [],
+            device_calendar_open_in: next.device_calendar_open_in ?? 'gaply'
           };
           localStorage.setItem(`gaply_device_calendar_${userId}`, JSON.stringify(devicePrefs));
         } catch {}

--- a/components/__tests__/SettingsContent.test.tsx
+++ b/components/__tests__/SettingsContent.test.tsx
@@ -107,6 +107,7 @@ describe('SettingsContent device calendar toggle', () => {
     const stored = JSON.parse(localStorage.getItem('gaply_device_calendar_user1') || '{}');
     expect(stored.show_device_calendar_busy).toBe(false);
     expect(stored.show_device_calendar_titles).toBe(false);
+    expect(stored.device_calendar_open_in).toBe('gaply');
 
     const updatedPrefs = onUpdate.mock.calls[0][0] as UserPreferences;
     await act(async () => {
@@ -127,6 +128,7 @@ describe('SettingsContent device calendar toggle', () => {
     const storedAgain = JSON.parse(localStorage.getItem('gaply_device_calendar_user1') || '{}');
     expect(storedAgain.show_device_calendar_busy).toBe(false);
     expect(storedAgain.show_device_calendar_titles).toBe(false);
+    expect(storedAgain.device_calendar_open_in).toBe('gaply');
   });
 });
 

--- a/types/index.tsx
+++ b/types/index.tsx
@@ -71,6 +71,7 @@ export interface UserPreferences {
   show_device_calendar_busy?: boolean;           // default false
   show_device_calendar_titles?: boolean;         // default false
   device_calendar_included_ids?: string[];       // default []
+  device_calendar_open_in?: 'gaply' | 'calendar_app';
   calendar_all_day_block_mode?: 'workday' | 'window' | 'ignore';
   calendar_all_day_fixed_block_minutes?: number;
   calendar_all_day_fixed_block_start?: 'start' | 'middle' | 'end';

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -13,6 +13,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   show_device_calendar_busy: false,
   show_device_calendar_titles: false,
   device_calendar_included_ids: [],
+  device_calendar_open_in: 'gaply',
   // Calendar Busy Handling
   calendar_all_day_block_mode: 'workday',
   calendar_all_day_fixed_block_minutes: 30,

--- a/utils/localFirst/EnhancedLoginSyncService.ts
+++ b/utils/localFirst/EnhancedLoginSyncService.ts
@@ -384,6 +384,7 @@ export class EnhancedLoginSyncService {
         let fallbackBusy = false;
         let fallbackTitles = false;
         let fallbackIds: string[] = [];
+        let fallbackOpenIn: 'gaply' | 'calendar_app' = 'gaply';
         try {
           const raw = localStorage.getItem(`gaply_device_calendar_${this.userId || 'local-user'}`);
           if (raw) {
@@ -391,6 +392,7 @@ export class EnhancedLoginSyncService {
             fallbackBusy = !!fb.show_device_calendar_busy;
             fallbackTitles = !!fb.show_device_calendar_titles;
             fallbackIds = Array.isArray(fb.device_calendar_included_ids) ? fb.device_calendar_included_ids : [];
+            fallbackOpenIn = fb.device_calendar_open_in === 'calendar_app' ? 'calendar_app' : 'gaply';
           }
         } catch {}
 
@@ -406,6 +408,9 @@ export class EnhancedLoginSyncService {
             Array.isArray(localPreferences?.device_calendar_included_ids)
               ? (localPreferences!.device_calendar_included_ids as any)
               : (fallbackIds as any)
+          ) as any,
+          device_calendar_open_in: (
+            (localPreferences?.device_calendar_open_in as any) ?? (fallbackOpenIn as any) ?? 'gaply'
           ) as any,
         } as UserPreferences;
 

--- a/utils/storage/EnhancedStorageManager.ts
+++ b/utils/storage/EnhancedStorageManager.ts
@@ -695,6 +695,7 @@ export class EnhancedStorageManager {
           device_calendar_included_ids: (Array.isArray(fb.device_calendar_included_ids)
             ? fb.device_calendar_included_ids
             : (prefs.device_calendar_included_ids ?? [])) as any,
+          device_calendar_open_in: (fb.device_calendar_open_in ?? prefs.device_calendar_open_in ?? 'gaply') as any,
         } as UserPreferences;
         // Persist merged locally if anything changed
         if (JSON.stringify(merged) !== JSON.stringify(prefs)) {

--- a/utils/storage/PreferenceManager.ts
+++ b/utils/storage/PreferenceManager.ts
@@ -508,6 +508,7 @@ export class PreferenceManager {
             show_device_calendar_busy: (localStored as any).show_device_calendar_busy ?? false,
             show_device_calendar_titles: (localStored as any).show_device_calendar_titles ?? false,
             device_calendar_included_ids: (localStored as any).device_calendar_included_ids ?? [],
+            device_calendar_open_in: (localStored as any).device_calendar_open_in ?? 'gaply',
           } as UserPreferences;
         }
       } catch {}

--- a/utils/storage/__tests__/filterServerEligiblePrefs.test.ts
+++ b/utils/storage/__tests__/filterServerEligiblePrefs.test.ts
@@ -7,6 +7,7 @@ describe('filterServerEligiblePrefs', () => {
       show_device_calendar_busy: true,
       show_device_calendar_titles: true,
       device_calendar_included_ids: ['1','2'],
+      device_calendar_open_in: 'gaply',
       calendar_work_start: '09:00',
     } as any;
 
@@ -15,6 +16,7 @@ describe('filterServerEligiblePrefs', () => {
     expect((filtered as any).show_device_calendar_busy).toBeUndefined();
     expect((filtered as any).show_device_calendar_titles).toBeUndefined();
     expect((filtered as any).device_calendar_included_ids).toBeUndefined();
+    expect((filtered as any).device_calendar_open_in).toBeUndefined();
   });
 
   it('preserves server-whitelisted fields only', () => {
@@ -25,6 +27,7 @@ describe('filterServerEligiblePrefs', () => {
       dark_mode: true,
       // non-whitelisted
       device_calendar_included_ids: ['a'],
+      device_calendar_open_in: 'gaply',
     } as any;
 
     const filtered = filterServerEligiblePrefs(diff);
@@ -41,6 +44,7 @@ describe('filterServerEligiblePrefs', () => {
       show_device_calendar_busy: true,
       show_device_calendar_titles: false,
       device_calendar_included_ids: [],
+      device_calendar_open_in: 'gaply',
     } as any;
     const filtered = filterServerEligiblePrefs(diff);
     expect(filtered).toEqual({});


### PR DESCRIPTION
## Summary
- support choosing whether device calendar events open in Gaply or the native app
- persist device calendar open preference locally and exclude from server sync
- extend storage managers and login sync to merge device calendar open preference

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8447b9a90832ba4638ea657671a99