### PR TITLE
refactor: remove hidden horizontal overflow

### DIFF
--- a/components/HomeContent.tsx
+++ b/components/HomeContent.tsx
@@ -111,7 +111,7 @@ export function HomeContent({
             <ChevronRight className="w-5 h-5" />
           </div>
           
-          <div className="flex gap-3 overflow-x-auto pb-2">
+          <div className="flex flex-wrap gap-3 pb-2">
             {(suggestions || []).map((suggestion) => (
               <div 
                 key={suggestion.id}

--- a/components/MobileOptimizations.tsx
+++ b/components/MobileOptimizations.tsx
@@ -110,13 +110,11 @@ export function MobileOptimizations() {
         -webkit-text-size-adjust: 100%;
         -ms-text-size-adjust: 100%;
         height: 100%;
-        overflow-x: hidden;
       }
       
       /* Enhanced body styling for mobile */
       body {
         height: 100%;
-        overflow-x: hidden;
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: none;
         overscroll-behavior-y: none;
@@ -125,7 +123,6 @@ export function MobileOptimizations() {
       /* Root container styling */
       #root {
         height: 100%;
-        overflow-x: hidden;
       }
       
       /* Better touch targets for mobile */

--- a/components/PlannerContent.tsx
+++ b/components/PlannerContent.tsx
@@ -811,43 +811,19 @@ function PlannerContent({
               </button>
             </div>
           ) : (
-          <div
-            className="flex items-center gap-3 overflow-x-auto ios-scroll android-scroll pb-4 px-8" 
-            style={{ 
-              scrollbarWidth: 'none', 
-              msOverflowStyle: 'none',
-              WebkitOverflowScrolling: 'touch',
-              scrollSnapType: 'x mandatory'
-            }}
-            ref={(el) => {
-              // Auto-scroll to today on mount
-              if (el && !el.dataset.scrolled) {
-                const today = startOfDay(new Date());
-                const index = dateTabs.findIndex(tab => isSameDay(tab.date, today));
-                const targetChild = index >= 0 ? (el.children[index] as HTMLElement) : (el.children[0] as HTMLElement);
-                if (targetChild) {
-                  const containerWidth = el.offsetWidth;
-                  const buttonWidth = targetChild.offsetWidth;
-                  const scrollLeft = targetChild.offsetLeft - (containerWidth / 2) + (buttonWidth / 2);
-                  el.scrollTo({ left: Math.max(0, scrollLeft), behavior: 'smooth' });
-                }
-                el.dataset.scrolled = 'true';
-              }
-            }}
-          >
+          <div className="flex flex-wrap items-center gap-3 pb-4 px-8">
             {dateTabs.map((tab) => (
               <button
                 key={tab.date.toISOString()}
                 onClick={() => setSelectedDate(tab.date)}
                 className={`
-                  px-4 py-2 rounded-2xl transition-all whitespace-nowrap text-sm font-medium min-w-fit touch-manipulation flex-shrink-0
+                  px-4 py-2 rounded-2xl transition-all whitespace-nowrap text-sm font-medium
                   ${isSameDay(selectedDate, tab.date)
                     ? 'bg-blue-600 text-white shadow-lg scale-105'
                     : 'bg-slate-800/50 text-slate-300 hover:bg-slate-700/50 active:bg-slate-600/50'
                   }
                   ${tab.isToday ? 'ring-2 ring-blue-400/30' : ''}
                 `}
-                style={{ scrollSnapAlign: 'center' }}
                 type="button"
               >
                 {tab.label}
@@ -879,7 +855,7 @@ function PlannerContent({
                 setSelectedDate(targetDate);
                 setTimeout(scrollToCurrentTime, 150);
               }}
-              className="px-3 py-2 bg-slate-700/30 hover:bg-slate-600/30 text-slate-300 hover:text-white rounded-2xl transition-all whitespace-nowrap text-sm font-medium min-w-fit touch-manipulation flex-shrink-0 border border-slate-600/30 hover:border-slate-500/50"
+              className="px-3 py-2 bg-slate-700/30 hover:bg-slate-600/30 text-slate-300 hover:text-white rounded-2xl transition-all whitespace-nowrap text-sm font-medium border border-slate-600/30 hover:border-slate-500/50"
               type="button"
               title="Jump to today and current time"
             >

--- a/components/TaskTile.tsx
+++ b/components/TaskTile.tsx
@@ -89,8 +89,8 @@ export function TaskTile({ task, onEdit, onTimer, onComplete, onDelete, onSchedu
       {/* Background actions */}
       <div className="absolute inset-0 flex">
         {/* Complete action (left side) */}
-        <motion.div 
-          className="flex items-center justify-center bg-green-500 w-[84px] shrink-0"
+        <motion.div
+          className="flex items-center justify-center bg-green-500 basis-20"
           style={{ opacity: completeOpacity }}
           onClick={(e) => {
             // Clicking the background (not the button) should close actions
@@ -113,8 +113,8 @@ export function TaskTile({ task, onEdit, onTimer, onComplete, onDelete, onSchedu
         <div className="flex-1" />
         
         {/* Delete action (right side) */}
-        <motion.div 
-          className="flex items-center justify-center bg-red-500 w-[84px] shrink-0"
+        <motion.div
+          className="flex items-center justify-center bg-red-500 basis-20"
           style={{ opacity: deleteOpacity }}
           onClick={(e) => {
             // Clicking the background (not the button) should close actions

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,10 +6,7 @@ import { cn } from "./utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full">
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
         background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
         color: white;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', system-ui, sans-serif;
-        overflow-x: hidden;
       }
       
       /* Loading spinner */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -261,27 +261,6 @@
 /* Ensure smooth scrolling for touch devices */
 body, html {
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-body::-webkit-scrollbar,
-html::-webkit-scrollbar {
-  display: none;
-}
-
-/* Hide scrollbars for any scrollable containers */
-.overflow-y-auto::-webkit-scrollbar,
-.overflow-x-auto::-webkit-scrollbar,
-.overflow-auto::-webkit-scrollbar {
-  display: none;
-}
-
-.overflow-y-auto,
-.overflow-x-auto,
-.overflow-auto {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
 /* Enhanced mobile touch scrolling */
@@ -403,7 +382,7 @@ html::-webkit-scrollbar {
     left: 16px !important;
     right: 16px !important;
     transform: none !important;
-    width: calc(100vw - 32px) !important;
+    width: calc(100% - 32px) !important;
   }
   
   .ios-toast {


### PR DESCRIPTION
## Summary
- let suggestion tiles and planner date buttons wrap instead of forcing horizontal scroll
- stop masking overflow in global and mobile styles
- drop fixed widths on table wrapper and task tile actions for flexible layouts

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68a9ea598868832b99c5014ddf48b763